### PR TITLE
js-beautify needs stdin file at the end of command line

### DIFF
--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -55,7 +55,7 @@ endif
 
 if !exists("g:formatprg_javascript") | let g:formatprg_javascript = "js-beautify" | endif
 if !exists("g:formatprg_args_expr_javascript") && !exists("g:formatprg_args_javascript")
-    let g:formatprg_args_expr_javascript = '"-f - -".(&expandtab ? "s ".&shiftwidth : "t").(&textwidth ? " -w ".&textwidth : "")'
+    let g:formatprg_args_expr_javascript = '"-f -".(&expandtab ? "s ".&shiftwidth : "t").(&textwidth ? " -w ".&textwidth : "")." -"'
 endif
 
 if !exists("g:formatprg_json") | let g:formatprg_json = "js-beautify" | endif


### PR DESCRIPTION
Thanks for the great plugin. ``js-beautify`` only worked for me when I move the "-" denoting stdin to the end of the command line. Maybe the current behaviour differs from past versions.