### PR TITLE
Added TypeScript formatting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ let g:formatprg_args_expr_javascript = '"-".(&expandtab ? "s ".&shiftwidth : "t"
 ```
 Here is the link to the repository: https://github.com/einars/js-beautify.
 
+* `typescript-formatter` for __Typescript__.
+`typescript-formatter` is a thin wrapper around the TypeScript compiler services.
+It can be installed by running `npm install -g typescript-formatter`.
+Note that `nodejs` is needed for this to work. 
+Here is the link to the repository: https://github.com/vvakame/typescript-formatter.
+
 * `html-beautify` for __HTML__.
 It is shipped with `js-beautify`, which can be installed by running `npm install -g js-beautify`.
 Note that `nodejs` is needed for this to work.

--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -58,6 +58,11 @@ if !exists("g:formatprg_args_expr_javascript") && !exists("g:formatprg_args_java
     let g:formatprg_args_expr_javascript = '"-f - -".(&expandtab ? "s ".&shiftwidth : "t").(&textwidth ? " -w ".&textwidth : "")'
 endif
 
+if !exists("g:formatprg_typescript") | let g:formatprg_typescript = "tsfmt" | endif
+if !exists("g:formatprg_args_expr_typescript") && !exists("g:formatprg_args_typescript")
+    let g:formatprg_args_expr_typescript = '"--stdin %"'
+endif
+
 if !exists("g:formatprg_json") | let g:formatprg_json = "js-beautify" | endif
 if !exists("g:formatprg_args_expr_json") && !exists("g:formatprg_args_json")
     let g:formatprg_args_expr_json = '"-f - -".(&expandtab ? "s ".&shiftwidth : "t")'


### PR DESCRIPTION
vvakame/typescript-formatter now support reading from stdin, but a
filename has to be specified. I've tried it with both unsaved and saved
buffers and it works fine.