### PR TITLE
Fix restoring winview after formatting (regression since 55fca18a)

### DIFF
--- a/plugin/autoformat.vim
+++ b/plugin/autoformat.vim
@@ -153,7 +153,7 @@ endfunction
 
 
 " Create a command for formatting the entire buffer
-command! -nargs=? -range=% -complete=filetype Autoformat <line1>,<line2>call s:TryAllFormatters(<f-args>)
+command! -nargs=? -range=% -complete=filetype Autoformat call s:TryAllFormatters(<f-args>)
 
 
 " Functions for iterating through list of available formatters


### PR DESCRIPTION
I'm using vim-autoformat with astyle. Since the commit 55fca18a vim jumps to the top after formatting.
This pullrequest fixes that for me. I haven't tried it with autopep8 though.