### PR TITLE
Strip trailing newline from stdout

### DIFF
--- a/plugin/autoformat.vim
+++ b/plugin/autoformat.vim
@@ -147,6 +147,8 @@ if stderrdata:
         print('Failing config: {} '.format(repr(formatprg), stderrdata))
     vim.command('return 0')
 else:
+    if stdoutdata[-1] == '\n':
+        stdoutdata = stdoutdata[:-1]
     vim.current.buffer[:] = stdoutdata.split('\n')
 EOF
 
@@ -180,6 +182,8 @@ if stderrdata:
         print('Failing config: {} '.format(repr(formatprg), stderrdata))
     vim.command('return 0')
 else:
+    if stdoutdata[-1] == '\n':
+        stdoutdata = stdoutdata[:-1]
     #vim.current.buffer[:] = stdoutdata.split('\n')
     vim.current.buffer[:] = stdoutdata.split(b'\n')
 EOF


### PR DESCRIPTION
This may be related to #61.

Often shell commands will append a newline at the end of their output. `tsfmt` is one of these, when using `--stdin`. This patch will remove a single trailing `\n` character from the formatter's `stdout`. However, there is a possibility that this will strip a valid `\n` character from a file that has one whose formatter does not add a `\n` to `stdout`.

Maybe there should be a way to configure a formatter to indicate that a `\n` should be removed from `stdout`, but this was a quicker fix and works for my issues.

This patch also presumes unix line endings and likely will not work for dos formatted files.