### PR TITLE
 Make the formatter options be configureable in the vimrc

### DIFF
--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -4,32 +4,47 @@
 
 
 " Python
-let g:formatdef_autopep8 = '"autopep8 - --range ".a:firstline." ".a:lastline." ".(&textwidth ? "--max-line-length=".&textwidth : "")'
+if !exists('g:formatdef_autopep8')
+    let g:formatdef_autopep8 = '"autopep8 - --range ".a:firstline." ".a:lastline." ".(&textwidth ? "--max-line-length=".&textwidth : "")'
+endif
+
 if !exists('g:formatters_python')
     let g:formatters_python = ['autopep8']
 endif
 
 
 " C#
-let g:formatdef_astyle_cs = '"astyle --mode=cs --style=ansi --indent-namespaces -pcH".(&expandtab ? "s".&shiftwidth : "t")'
+if !exists('g:formatdef_astyle_cs')
+    let g:formatdef_astyle_cs = '"astyle --mode=cs --style=ansi --indent-namespaces -pcH".(&expandtab ? "s".&shiftwidth : "t")'
+endif
+
 if !exists('g:formatters_cs')
     let g:formatters_cs = ['astyle_cs']
 endif
 
 
 " Generic C, C++, Objective-C
-let g:formatdef_clangformat = "'clang-format -lines='.a:firstline.':'.a:lastline.' --assume-filename='.bufname('%').' -style=\"{BasedOnStyle: WebKit, AlignTrailingComments: true, '.(&textwidth ? 'ColumnLimit: '.&textwidth.', ' : '').(&expandtab ? 'UseTab: Never, IndentWidth: '.&shiftwidth : 'UseTab: Always').'}\"'"
+if !exists('g:formatdef_clangformat')
+    let g:formatdef_clangformat = "'clang-format -lines='.a:firstline.':'.a:lastline.' --assume-filename='.bufname('%').' -style=\"{BasedOnStyle: WebKit, AlignTrailingComments: true, '.(&textwidth ? 'ColumnLimit: '.&textwidth.', ' : '').(&expandtab ? 'UseTab: Never, IndentWidth: '.&shiftwidth : 'UseTab: Always').'}\"'"
+endif
+
 
 
 " C
-let g:formatdef_astyle_c = '"astyle --mode=c --style=ansi -pcH".(&expandtab ? "s".&shiftwidth : "t")'
+if !exists('g:formatdef_astyle_c')
+    let g:formatdef_astyle_c = '"astyle --mode=c --style=ansi -pcH".(&expandtab ? "s".&shiftwidth : "t")'
+endif
+
 if !exists('g:formatters_c')
     let g:formatters_c = ['clangformat', 'astyle_c']
 endif
 
 
 " C++
-let g:formatdef_astyle_cpp = '"astyle --mode=c --style=ansi -pcH".(&expandtab ? "s".&shiftwidth : "t")'
+if !exists('g:formatdef_astyle_cpp')
+    let g:formatdef_astyle_cpp = '"astyle --mode=c --style=ansi -pcH".(&expandtab ? "s".&shiftwidth : "t")'
+endif
+
 if !exists('g:formatters_cpp')
     let g:formatters_cpp = ['clangformat', 'astyle_cpp']
 endif
@@ -42,16 +57,28 @@ endif
 
 
 " Java
-let g:formatdef_astyle_java = '"astyle --mode=java --style=ansi -pcH".(&expandtab ? "s".&shiftwidth : "t")'
+if !exists('g:formatdef_astyle_java')
+    let g:formatdef_astyle_java = '"astyle --mode=java --style=ansi -pcH".(&expandtab ? "s".&shiftwidth : "t")'
+endif
+
 if !exists('g:formatters_java')
     let g:formatters_java = ['astyle_java']
 endif
 
 
 " Javascript
-let g:formatdef_jsbeautify_javascript = '"js-beautify -f - -".(&expandtab ? "s ".&shiftwidth : "t").(&textwidth ? " -w ".&textwidth : "")'
-let g:formatdef_pyjsbeautify_javascript = '"js-beautify -".(&expandtab ? "s ".&shiftwidth : "t").(&textwidth ? " -w ".&textwidth : "")." -"'
-let g:formatdef_jscs = '"jscs -x"'
+if !exists('g:formatdef_jsbeautify_javascript')
+    let g:formatdef_jsbeautify_javascript = '"js-beautify -f - -".(&expandtab ? "s ".&shiftwidth : "t").(&textwidth ? " -w ".&textwidth : "")'
+endif
+
+if !exists('g:formatdef_pyjsbeautify_javascript')
+    let g:formatdef_pyjsbeautify_javascript = '"js-beautify -".(&expandtab ? "s ".&shiftwidth : "t").(&textwidth ? " -w ".&textwidth : "")." -"'
+endif
+
+if !exists('g:formatdef_jscs')
+    let g:formatdef_jscs = '"jscs -x"'
+endif
+
 if !exists('g:formatters_javascript')
     let g:formatters_javascript = [
                 \ 'jsbeautify_javascript',
@@ -62,8 +89,14 @@ endif
 
 
 " JSON
-let g:formatdef_jsbeautify_json = '"js-beautify -f - -".(&expandtab ? "s ".&shiftwidth : "t")'
-let g:formatdef_pyjsbeautify_json = '"js-beautify -".(&expandtab ? "s ".&shiftwidth : "t")." -"'
+if !exists('g:formatdef_jsbeautify_json')
+    let g:formatdef_jsbeautify_json = '"js-beautify -f - -".(&expandtab ? "s ".&shiftwidth : "t")'
+endif
+
+if !exists('g:formatdef_pyjsbeautify_json')
+    let g:formatdef_pyjsbeautify_json = '"js-beautify -".(&expandtab ? "s ".&shiftwidth : "t")." -"'
+endif
+
 if !exists('g:formatters_json')
     let g:formatters_json = [
                 \ 'jsbeautify_json',
@@ -73,8 +106,14 @@ endif
 
 
 " HTML
-let g:formatdef_htmlbeautify = '"html-beautify -f - -s ".&shiftwidth'
-let g:formatdef_tidy_html = '"tidy -q --show-errors 0 --show-warnings 0 --force-output --indent auto --indent-spaces ".&shiftwidth." --vertical-space yes --tidy-mark no -wrap ".&textwidth'
+if !exists('g:formatdef_htmlbeautify')
+    let g:formatdef_htmlbeautify = '"html-beautify -f - -s ".&shiftwidth'
+endif
+
+if !exists('g:formatdef_tidy_html')
+    let g:formatdef_tidy_html = '"tidy -q --show-errors 0 --show-warnings 0 --force-output --indent auto --indent-spaces ".&shiftwidth." --vertical-space yes --tidy-mark no -wrap ".&textwidth'
+endif
+
 if !exists('g:formatters_html')
     let g:formatters_html = ['htmlbeautify', 'tidy_html']
 endif
@@ -82,41 +121,59 @@ endif
 
 
 " XML
-let g:formatdef_tidy_xml = '"tidy -q -xml --show-errors 0 --show-warnings 0 --force-output --indent auto --indent-spaces ".&shiftwidth." --vertical-space yes --tidy-mark no -wrap ".&textwidth'
+if !exists('g:formatdef_tidy_xml')
+    let g:formatdef_tidy_xml = '"tidy -q -xml --show-errors 0 --show-warnings 0 --force-output --indent auto --indent-spaces ".&shiftwidth." --vertical-space yes --tidy-mark no -wrap ".&textwidth'
+endif
+
 if !exists('g:formatters_xml')
     let g:formatters_xml = ['tidy_xml']
 endif
 
 
 " XHTML
-let g:formatdef_tidy_xhtml = '"tidy -q --show-errors 0 --show-warnings 0 --force-output --indent auto --indent-spaces ".&shiftwidth." --vertical-space yes --tidy-mark no -asxhtml -wrap ".&textwidth'
+if !exists('g:formatdef_tidy_xhtml')
+    let g:formatdef_tidy_xhtml = '"tidy -q --show-errors 0 --show-warnings 0 --force-output --indent auto --indent-spaces ".&shiftwidth." --vertical-space yes --tidy-mark no -asxhtml -wrap ".&textwidth'
+endif
+
 if !exists('g:formatters_xhtml')
     let g:formatters_xhtml = ['tidy_xhtml']
 endif
 
 " Ruby
-let g:formatdef_rbeautify = '"rbeautify ".(&expandtab ? "-s -c ".&shiftwidth : "-t")'
+if !exists('g:formatdef_rbeautify')
+    let g:formatdef_rbeautify = '"rbeautify ".(&expandtab ? "-s -c ".&shiftwidth : "-t")'
+endif
+
 if !exists('g:formatters_ruby')
     let g:formatters_ruby = ['rbeautify']
 endif
 
 
 " CSS
-let g:formatdef_cssbeautify = '"css-beautify -f - -s ".&shiftwidth'
+if !exists('g:formatdef_cssbeautify')
+    let g:formatdef_cssbeautify = '"css-beautify -f - -s ".&shiftwidth'
+endif
+
 if !exists('g:formatters_css')
     let g:formatters_css = ['cssbeautify']
 endif
 
 
 " SCSS
-let g:formatdef_sassconvert = '"sass-convert -F scss -T scss --indent " . (&expandtab ? &shiftwidth : "t")'
+if !exists('g:formatdef_sassconvert')
+    let g:formatdef_sassconvert = '"sass-convert -F scss -T scss --indent " . (&expandtab ? &shiftwidth : "t")'
+endif
+
 if !exists('g:formatters_scss')
     let g:formatters_scss = ['sassconvert']
 endif
 
 
 " Typescript
-let g:formatdef_tsfmt = '"tsfmt --stdin %"'
+if !exists('g:formatdef_tsfmt')
+    let g:formatdef_tsfmt = '"tsfmt --stdin %"'
+endif
+
 if !exists('g:formatters_typescript')
     let g:formatters_typescript = ['tsfmt']
 endif
@@ -125,8 +182,14 @@ endif
 " Golang
 " Two definitions are provided for two versions of gofmt.
 " See issue #59
-let g:formatdef_gofmt_1 = '"gofmt -tabs=".(&expandtab ? "false" : "true")." -tabwidth=".&shiftwidth'
-let g:formatdef_gofmt_2 = '"gofmt"'
+if !exists('g:formatdef_gofmt_1')
+    let g:formatdef_gofmt_1 = '"gofmt -tabs=".(&expandtab ? "false" : "true")." -tabwidth=".&shiftwidth'
+endif
+
+if !exists('g:formatdef_gofmt_2')
+    let g:formatdef_gofmt_2 = '"gofmt"'
+endif
+
 if !exists('g:formatters_go')
     let g:formatters_go = ['gofmt_1', 'gofmt_2']
 endif


### PR DESCRIPTION
In the Readme.rd it was stated that the formatter can be configured using g:formatdef_clangformat. This did not work. The reason for this is that the global variables are set after the vimrc is loaded, so in this fix I am including an if !exists check.