### PR TITLE
fix for using the default gg=G on files without formatting definition…

### DIFF
--- a/plugin/autoformat.vim
+++ b/plugin/autoformat.vim
@@ -60,6 +60,7 @@ endfunction
 function! s:TryAllFormatters(...) range
     " Make sure formatters are defined and detected
     if !call('<SID>find_formatters', a:000)
+        exe "normal gg=G"
         return 0
     endif
 
@@ -106,6 +107,7 @@ function! s:TryAllFormatters(...) range
 
         if s:index == b:current_formatter_index
             " Tried all formatters, none worked
+            exe "normal gg=G"
             return 0
         endif
     endwhile


### PR DESCRIPTION
…s at all

somewhere along the road of changing the way formating defentions were made the default fallback of doing gg=G got lost so added that back with this