### PR TITLE
fix endline in python3

### DIFF
--- a/plugin/autoformat.vim
+++ b/plugin/autoformat.vim
@@ -188,8 +188,9 @@ else:
     # It is not entirely clear when and why that happens.
     # However, extra newlines are almost never required, while there are linters that complain
     # about superfluous newlines, so we remove one empty newline at the end of the file.
-    if stdoutdata[-1] == os.linesep:
-        stdoutdata = stdoutdata[:-1]
+    stdoutdata_decoded = stdoutdata.decode('utf-8')
+    if stdoutdata_decoded[-1] == os.linesep:
+        stdoutdata = stdoutdata_decoded[:-1]
     vim.current.buffer[:] = stdoutdata.split(os.linesep)
 EOF
 


### PR DESCRIPTION
relating to #76 

the output from p.communicate() is a byte string, os.linesep returns a string.

I first tried to convert os.linesep into a byte and do the comparison, but it did not compare properly, so in the else, I converted the entire stdoutdata into a string, then did the normal comparison and it appears to have fixed it for Python3.5 on Arch Linux.