### PR TITLE
Proof of concept: use formatexpr

### DIFF
--- a/autoload/autoformat.vim
+++ b/autoload/autoformat.vim
@@ -1,10 +1,125 @@
 function! autoformat#formatexpr()
-  " Use internal method for single lines / autoformatting.
-  if v:count == 1
+  " Use Vim's internal method for autoformatting.
+  " if v:char != '' || index(['i', 'R'], mode()) != -1
+  if v:char != ''
     return 1
   endif
-  " let winview=winsaveview()
-  exe v:lnum.";+".(v:count-1).' call TryAllFormatters()'
-  " call winrestview(winview)
+
+  let winview=winsaveview()
+  exe v:lnum.";+".(v:count-1).' call autoformat#TryAllFormatters()'
+  call winrestview(winview)
   return 0
+endfunction
+
+
+" Try all formatters, starting with the currently selected one, until one
+" works. If none works, autoindent the buffer.
+function! autoformat#TryAllFormatters(...) range
+    " Make sure formatters are defined and detected
+    if !call('autoformat#find_formatters', a:000)
+        " No formatters defined, so autoindent code.
+        exe a:firstline . "normal! =" . (a:lastline - a:firstline) . "j"
+        return 0
+    endif
+
+    " Make sure index exists and is valid.
+    if !exists('b:current_formatter_index')
+        let b:current_formatter_index = 0
+    endif
+    if b:current_formatter_index >= len(b:formatters)
+        let b:current_formatter_index = 0
+    endif
+
+    " Try all formatters, starting with selected one
+    let s:index = b:current_formatter_index
+
+    let verbose = &verbose || exists("g:autoformat_verbosemode")
+    while 1
+        let formatdef_var = 'g:formatdef_'.b:formatters[s:index]
+        " Formatter definition must be existent
+        if !exists(formatdef_var)
+            echoerr "No format definition found in '".formatdef_var."'."
+            return 0
+        endif
+
+        " Eval twice, once for getting definition content,
+        " once for getting the final expression
+        let formatter = eval(eval(formatdef_var))
+
+        if verbose
+          echom "autoformat: calling:" formatter
+        endif
+        exe '% !'.formatter
+
+        if v:shell_error == 0
+            return 1
+        else
+            undo
+            let s:index = (s:index + 1) % len(b:formatters)
+        endif
+
+        if s:index == b:current_formatter_index
+            " Tried all formatters, none worked so autoindent code.
+            exe a:firstline . "normal! =" . (a:lastline - a:firstline) . "j"
+            return 0
+        endif
+    endwhile
+
+endfunction
+
+
+" Function for finding the formatters for this filetype
+" Result is stored in b:formatters
+function! autoformat#find_formatters(...)
+    " Detect verbosity
+    let verbose = &verbose || exists("g:autoformat_verbosemode")
+
+    " Extract filetype to be used
+    let ftype = a:0 ? a:1 : &filetype
+    " Support composite filetypes by replacing dots with underscores
+    let compoundtype = substitute(ftype, "[.]", "_", "g")
+    if ftype =~ "[.]"
+        " Try all super filetypes in search for formatters in a sane order
+        let ftypes = [compoundtype] + split(ftype, "[.]")
+    else
+        let ftypes = [compoundtype]
+    endif
+
+    " Warn for backward incompatible configuration
+    let old_formatprg_var = "g:formatprg_".compoundtype
+    let old_formatprg_args_var = "g:formatprg_args_".compoundtype
+    let old_formatprg_args_expr_var = "g:formatprg_args_expr_".compoundtype
+    if exists(old_formatprg_var) || exists(old_formatprg_args_var) || exists(old_formatprg_args_expr_var)
+        echohl WarningMsg |
+          \ echomsg "WARNING: the options g:formatprg_<filetype>, g:formatprg_args_<filetype> and g:formatprg_args_expr_<filetype> are no longer supported as of June 2015, due to major backward-incompatible improvements. Please check the README for help on how to configure your formatters." |
+          \ echohl None
+    endif
+
+    " Detect configuration for all possible ftypes
+    let b:formatters = []
+    for supertype in ftypes
+        let formatters_var = "g:formatters_".supertype
+        if !exists(formatters_var)
+            " No formatters defined
+            if verbose
+                echoerr "No formatters defined for supertype '".supertype
+            endif
+        else
+            let formatters = eval(formatters_var)
+            if type(formatters) != 3
+                echoerr formatter_var." is not a list"
+            else
+                let b:formatters = b:formatters + formatters
+            endif
+        endif
+    endfor
+
+    if len(b:formatters) == 0
+        " No formatters defined
+        if verbose
+            echoerr "No formatters defined for filetype '".ftype."'."
+        endif
+        return 0
+    endif
+    return 1
 endfunction

--- a/autoload/autoformat.vim
+++ b/autoload/autoformat.vim
@@ -1,3 +1,10 @@
 function! autoformat#formatexpr()
+  " Use internal method for single lines / autoformatting.
+  if v:count == 1
+    return 1
+  endif
+  " let winview=winsaveview()
   exe v:lnum.";+".(v:count-1).' call TryAllFormatters()'
+  " call winrestview(winview)
+  return 0
 endfunction

--- a/autoload/autoformat.vim
+++ b/autoload/autoformat.vim
@@ -1,3 +1,3 @@
 function! autoformat#formatexpr()
-  exe v:lnum.";+".(v:count-1).' call TryAllFormatters(1)'
+  exe v:lnum.";+".(v:count-1).' call TryAllFormatters()'
 endfunction

--- a/autoload/autoformat.vim
+++ b/autoload/autoformat.vim
@@ -1,0 +1,3 @@
+function! autoformat#formatexpr()
+  exe v:lnum.";+".(v:count-1).' call TryAllFormatters(1)'
+endfunction

--- a/plugin/autoformat.vim
+++ b/plugin/autoformat.vim
@@ -58,7 +58,7 @@ set formatexpr=autoformat#formatexpr()
 
 " Try all formatters, starting with the currently selected one, until one
 " works. If none works, autoindent the buffer.
-function! TryAllFormatters(replace, ...) range
+function! TryAllFormatters(...) range
     " Make sure formatters are defined and detected
     if !call('<SID>find_formatters', a:000)
         " No formatters defined, so autoindent code.
@@ -66,7 +66,7 @@ function! TryAllFormatters(replace, ...) range
         return 0
     endif
 
-    " Make sure index exist and is valid
+    " Make sure index exists and is valid.
     if !exists('b:current_formatter_index')
         let b:current_formatter_index = 0
     endif
@@ -97,9 +97,9 @@ function! TryAllFormatters(replace, ...) range
             return 1
         endif
         if has("python")
-            let success = s:TryFormatterPython(a:replace)
+            let success = s:TryFormatterPython()
         else
-            let success = s:TryFormatterPython3(a:replace)
+            let success = s:TryFormatterPython3()
         endif
         if success
             return 1
@@ -122,7 +122,7 @@ endfunction
 " Otherwise, return 0
 
 " +python version
-function! s:TryFormatterPython(replace)
+function! s:TryFormatterPython()
     " Detect verbosity
     let verbose = &verbose || exists("g:autoformat_verbosemode")
 

--- a/plugin/autoformat.vim
+++ b/plugin/autoformat.vim
@@ -60,8 +60,8 @@ endfunction
 function! s:TryAllFormatters(...) range
     " Make sure formatters are defined and detected
     if !call('<SID>find_formatters', a:000)
-        " No formatters defined, so autoindent code
-        exe "normal gg=G"
+        " No formatters defined, so autoindent code.
+        exe a:firstline . "normal! =" . (a:lastline - a:firstline) . "j"
         return 0
     endif
 
@@ -107,8 +107,8 @@ function! s:TryAllFormatters(...) range
         endif
 
         if s:index == b:current_formatter_index
-            " Tried all formatters, none worked so autoindent code
-            exe "normal gg=G"
+            " Tried all formatters, none worked so autoindent code.
+            exe a:firstline . "normal! =" . (a:lastline - a:firstline) . "j"
             return 0
         endif
     endwhile

--- a/plugin/autoformat.vim
+++ b/plugin/autoformat.vim
@@ -1,212 +1,22 @@
-" Function for finding the formatters for this filetype
-" Result is stored in b:formatters
-function! s:find_formatters(...)
-    " Detect verbosity
-    let verbose = &verbose || exists("g:autoformat_verbosemode")
+if exists('g:loaded_autoformat')
+  finish
+endif
+let g:loaded_autoformat = 1
 
-    " Extract filetype to be used
-    let ftype = a:0 ? a:1 : &filetype
-    " Support composite filetypes by replacing dots with underscores
-    let compoundtype = substitute(ftype, "[.]", "_", "g")
-    if ftype =~ "[.]"
-        " Try all super filetypes in search for formatters in a sane order
-        let ftypes = [compoundtype] + split(ftype, "[.]")
-    else
-        let ftypes = [compoundtype]
-    endif
-
-    " Warn for backward incompatible configuration
-    let old_formatprg_var = "g:formatprg_".compoundtype
-    let old_formatprg_args_var = "g:formatprg_args_".compoundtype
-    let old_formatprg_args_expr_var = "g:formatprg_args_expr_".compoundtype
-    if exists(old_formatprg_var) || exists(old_formatprg_args_var) || exists(old_formatprg_args_expr_var)
-        echohl WarningMsg |
-          \ echomsg "WARNING: the options g:formatprg_<filetype>, g:formatprg_args_<filetype> and g:formatprg_args_expr_<filetype> are no longer supported as of June 2015, due to major backward-incompatible improvements. Please check the README for help on how to configure your formatters." |
-          \ echohl None
-    endif
-
-    " Detect configuration for all possible ftypes
-    let b:formatters = []
-    for supertype in ftypes
-        let formatters_var = "g:formatters_".supertype
-        if !exists(formatters_var)
-            " No formatters defined
-            if verbose
-                echoerr "No formatters defined for supertype '".supertype
-            endif
-        else
-            let formatters = eval(formatters_var)
-            if type(formatters) != 3
-                echoerr formatter_var." is not a list"
-            else
-                let b:formatters = b:formatters + formatters
-            endif
-        endif
-    endfor
-
-    if len(b:formatters) == 0
-        " No formatters defined
-        if verbose
-            echoerr "No formatters defined for filetype '".ftype."'."
-        endif
-        return 0
-    endif
-    return 1
-endfunction
-
-set formatexpr=autoformat#formatexpr()
-
-" Try all formatters, starting with the currently selected one, until one
-" works. If none works, autoindent the buffer.
-function! TryAllFormatters(...) range
-    " Make sure formatters are defined and detected
-    if !call('<SID>find_formatters', a:000)
-        " No formatters defined, so autoindent code.
-        exe a:firstline . "normal! =" . (a:lastline - a:firstline) . "j"
-        return 0
-    endif
-
-    " Make sure index exists and is valid.
-    if !exists('b:current_formatter_index')
-        let b:current_formatter_index = 0
-    endif
-    if b:current_formatter_index >= len(b:formatters)
-        let b:current_formatter_index = 0
-    endif
-
-    " Try all formatters, starting with selected one
-    let s:index = b:current_formatter_index
-
-    while 1
-        let formatdef_var = 'g:formatdef_'.b:formatters[s:index]
-        " Formatter definition must be existent
-        if !exists(formatdef_var)
-            echoerr "No format definition found in '".formatdef_var."'."
-            return 0
-        endif
-
-        " Eval twice, once for getting definition content,
-        " once for getting the final expression
-        let &formatprg = eval(eval(formatdef_var))
-
-        " Detect if +python or +python3 is available, and call the corresponding function
-        if !has("python") && !has("python3")
-            echohl WarningMsg |
-                \ echomsg "WARNING: vim has no support for python, but it is required to run the formatter!" |
-                \ echohl None
-            return 1
-        endif
-        if has("python")
-            let success = s:TryFormatterPython()
-        else
-            let success = s:TryFormatterPython3()
-        endif
-        if success
-            return 1
-        else
-            let s:index = (s:index + 1) % len(b:formatters)
-        endif
-
-        if s:index == b:current_formatter_index
-            " Tried all formatters, none worked so autoindent code.
-            exe a:firstline . "normal! =" . (a:lastline - a:firstline) . "j"
-            return 0
-        endif
-    endwhile
-
-endfunction
-
-
-" Call formatter
-" If stderr is empty, apply result, return 1
-" Otherwise, return 0
-
-" +python version
-function! s:TryFormatterPython()
-    " Detect verbosity
-    let verbose = &verbose || exists("g:autoformat_verbosemode")
-
-python << EOF
-import vim, subprocess, os
-from subprocess import Popen, PIPE
-
-text = os.linesep.join(vim.current.buffer[:])
-formatprg = vim.eval('&formatprg')
-verbose = bool(int(vim.eval('verbose')))
-env = os.environ.copy()
-if int(vim.eval('exists("g:formatterpath")')):
-    extra_path = vim.eval('g:formatterpath')
-    env['PATH'] = ':'.join(extra_path) + ':' + env['PATH']
-
-p = subprocess.Popen(formatprg, env=env, shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-stdoutdata, stderrdata = p.communicate(text)
-if stderrdata:
-    if verbose:
-        formattername = vim.eval('b:formatters[s:index]')
-        print('Formatter {} has errors: {}. Skipping.'.format(formattername, stderrdata))
-        print('Failing config: {} '.format(repr(formatprg), stderrdata))
-    vim.command('return 0')
-else:
-    # Often shell commands will append a newline at the end of their output.
-    # It is not entirely clear when and why that happens.
-    # However, extra newlines are almost never required, while there are linters that complain
-    # about superfluous newlines, so we remove one empty newline at the end of the file.
-    if stdoutdata[-1] == os.linesep:
-        stdoutdata = stdoutdata[:-1]
-    vim.current.buffer[:] = stdoutdata.split(os.linesep)
-EOF
-
-    return 1
-endfunction
-
-" +python3 version
-function! s:TryFormatterPython3()
-    " Detect verbosity
-    let verbose = &verbose || exists("g:autoformat_verbosemode")
-
-python3 << EOF
-import vim, subprocess, os
-from subprocess import Popen, PIPE
-
-text = bytes(os.linesep.join(vim.current.buffer[:]), 'utf-8')
-formatprg = vim.eval('&formatprg')
-verbose = bool(int(vim.eval('verbose')))
-env = os.environ.copy()
-if int(vim.eval('exists("g:formatterpath")')):
-    extra_path = vim.eval('g:formatterpath')
-    env['PATH'] = ':'.join(extra_path) + ':' + env['PATH']
-
-p = subprocess.Popen(formatprg, env=env, shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-stdoutdata, stderrdata = p.communicate(text)
-if stderrdata:
-    if verbose:
-        formattername = vim.eval('b:formatters[s:index]')
-        print('Formatter {} has errors: {}. Skipping.'.format(formattername, stderrdata))
-        print('Failing config: {} '.format(repr(formatprg), stderrdata))
-    vim.command('return 0')
-else:
-    # Often shell commands will append a newline at the end of their output.
-    # It is not entirely clear when and why that happens.
-    # However, extra newlines are almost never required, while there are linters that complain
-    # about superfluous newlines, so we remove one empty newline at the end of the file.
-    stdoutdata = stdoutdata.decode('utf-8')
-    if stdoutdata[-1] == os.linesep:
-        stdoutdata = stdoutdata[:-1]
-    vim.current.buffer[:] = stdoutdata.split(os.linesep)
-EOF
-
-    return 1
-endfunction
-
+" Setup formatexpr for buffers through FileType event.
+augroup autoformat
+    au!
+    autocmd FileType * set formatexpr=autoformat#formatexpr()
+augroup END
 
 " Create a command for formatting the entire buffer
 " Save and recall window state to prevent vim from jumping to line 1
-command! -nargs=? -range=% -complete=filetype Autoformat let winview=winsaveview()|<line1>,<line2>call TryAllFormatters(1, <f-args>)|call winrestview(winview)
+command! -nargs=? -range=% -complete=filetype Autoformat let winview=winsaveview()|<line1>,<line2>call autoformat#TryAllFormatters(<f-args>)|call winrestview(winview)
 
 
 " Functions for iterating through list of available formatters
 function! s:NextFormatter()
-    call s:find_formatters()
+    call autoformat#find_formatters()
     if !exists('b:current_formatter_index')
         let b:current_formatter_index = 0
     endif
@@ -215,7 +25,7 @@ function! s:NextFormatter()
 endfunction
 
 function! s:PreviousFormatter()
-    call s:find_formatters()
+    call autoformat#find_formatters()
     if !exists('b:current_formatter_index')
         let b:current_formatter_index = 0
     endif

--- a/plugin/autoformat.vim
+++ b/plugin/autoformat.vim
@@ -54,10 +54,11 @@ function! s:find_formatters(...)
     return 1
 endfunction
 
+set formatexpr=autoformat#formatexpr()
 
 " Try all formatters, starting with the currently selected one, until one
 " works. If none works, autoindent the buffer.
-function! s:TryAllFormatters(...) range
+function! TryAllFormatters(replace, ...) range
     " Make sure formatters are defined and detected
     if !call('<SID>find_formatters', a:000)
         " No formatters defined, so autoindent code.
@@ -96,9 +97,9 @@ function! s:TryAllFormatters(...) range
             return 1
         endif
         if has("python")
-            let success = s:TryFormatterPython()
+            let success = s:TryFormatterPython(a:replace)
         else
-            let success = s:TryFormatterPython3()
+            let success = s:TryFormatterPython3(a:replace)
         endif
         if success
             return 1
@@ -121,7 +122,7 @@ endfunction
 " Otherwise, return 0
 
 " +python version
-function! s:TryFormatterPython()
+function! s:TryFormatterPython(replace)
     " Detect verbosity
     let verbose = &verbose || exists("g:autoformat_verbosemode")
 
@@ -200,7 +201,7 @@ endfunction
 
 " Create a command for formatting the entire buffer
 " Save and recall window state to prevent vim from jumping to line 1
-command! -nargs=? -range=% -complete=filetype Autoformat let winview=winsaveview()|<line1>,<line2>call s:TryAllFormatters(<f-args>)|call winrestview(winview)
+command! -nargs=? -range=% -complete=filetype Autoformat let winview=winsaveview()|<line1>,<line2>call TryAllFormatters(1, <f-args>)|call winrestview(winview)
 
 
 " Functions for iterating through list of available formatters


### PR DESCRIPTION
Pretty much untested and needs cleaning up: most of the functions should be moved to `autoload` etc.

Using `formatexpr` will use this for `gq` automatically.

Ref: https://github.com/Chiel92/vim-autoformat/issues/80