### PR TITLE
Fix quotes to have the bufname evaluated dynamically

### DIFF
--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -171,7 +171,7 @@ endif
 
 " Typescript
 if !exists('g:formatdef_tsfmt')
-    let g:formatdef_tsfmt = '"tsfmt --stdin '.bufname('%').'"'
+    let g:formatdef_tsfmt = "'tsfmt --stdin '.bufname('%')"
 endif
 
 if !exists('g:formatters_typescript')


### PR DESCRIPTION
I noticed that the former form would get evaluated at vim launch and not when the command was executed, which had the wrong buffer name when the file was changed.

I looked at the other definitions in the file, and this one with the quotes inverted seems to work (I have zero experience in vim coding)