### PR TITLE
Add rustfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ This beautifier developed and tested with ruby `2.0+`, so you can have weird res
 The default golang formatting program is shipped with the golang distribution. Make sure `gofmt` is in your PATH (if golang is installed properly, it should be).
 Here is the link to the installation: https://golang.org/doc/install
 
+* `rustfmt` for __Rust__.
+It can be installed using `cargo`, the Rust package manager. Up-to-date installation instructions are on the project page: https://github.com/nrc/rustfmt/#installation.
+
 How can I change the behaviour of formatters, or add one myself?
 ----------------------------------------------------------------
 If you need a formatter that is not among the defaults, or if you are not satisfied with the default formatting behaviour that is provided by vim-autoformat, you can define it yourself.

--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -194,3 +194,12 @@ if !exists('g:formatters_go')
     let g:formatters_go = ['gofmt_1', 'gofmt_2']
 endif
 
+" Rust
+if !exists('g:formatdef_rustfmt')
+    let g:formatdef_rustfmt = '"rustfmt"'
+endif
+
+if !exists('g:formatters_rust')
+    let g:formatters_rust = ['rustfmt']
+endif
+


### PR DESCRIPTION
This adds rustfmt to the list of default formatters.