### PR TITLE
It looks like verbosity settings isn't working correctly. This change

### DIFF
--- a/plugin/autoformat.vim
+++ b/plugin/autoformat.vim
@@ -64,7 +64,9 @@ endfunction
 " works. If none works, autoindent the buffer.
 function! s:TryAllFormatters(...) range
     " Detect verbosity
-    let verbose = &verbose || exists("g:autoformat_verbosemode")
+    if exists("g:autoformat_verbosemode")
+      let verbose = g:autoformat_verbosemode
+    endif
 
     " Make sure formatters are defined and detected
     if !call('<SID>find_formatters', a:000)


### PR DESCRIPTION
makes the global variable work. However I'm still not sure if the
`verbose` variable ever worked.
I don't do vimscript often, so I hope this is good; it works for me.