### PR TITLE
astylerc not actually passing correct file

### DIFF
--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -53,7 +53,7 @@ endif
 " C#
 if !exists('g:formatdef_astyle_cs')
     if filereadable('.astylerc')
-        let g:formatdef_astyle_cs = '"astyle --mode=cs --options=.astyle"'
+        let g:formatdef_astyle_cs = '"astyle --mode=cs --options=.astylerc"'
     elseif filereadable(expand('~/.astylerc')) || exists('$ARTISTIC_STYLE_OPTIONS')
         let g:formatdef_astyle_cs = '"astyle --mode=cs"'
     else
@@ -82,7 +82,7 @@ endfunction
 " C
 if !exists('g:formatdef_astyle_c')
     if filereadable('.astylerc')
-        let g:formatdef_astyle_c = '"astyle --mode=c --options=.astyle"'
+        let g:formatdef_astyle_c = '"astyle --mode=c --options=.astylerc"'
     elseif filereadable(expand('~/.astylerc')) || exists('$ARTISTIC_STYLE_OPTIONS')
         let g:formatdef_astyle_c = '"astyle --mode=c"'
     else
@@ -98,7 +98,7 @@ endif
 " C++
 if !exists('g:formatdef_astyle_cpp')
     if filereadable('.astylerc')
-        let g:formatdef_astyle_cpp = '"astyle --mode=c --options=.astyle"'
+        let g:formatdef_astyle_cpp = '"astyle --mode=c --options=.astylerc"'
     elseif filereadable(expand('~/.astylerc')) || exists('$ARTISTIC_STYLE_OPTIONS')
         let g:formatdef_astyle_cpp = '"astyle --mode=c"'
     else
@@ -120,7 +120,7 @@ endif
 " Java
 if !exists('g:formatdef_astyle_java')
     if filereadable('.astylerc')
-        let g:formatdef_astyle_java = '"astyle --mode=java --options=.astyle"'
+        let g:formatdef_astyle_java = '"astyle --mode=java --options=.astylerc"'
     elseif filereadable(expand('~/.astylerc')) || exists('$ARTISTIC_STYLE_OPTIONS')
         let g:formatdef_astyle_java = '"astyle --mode=java"'
     else


### PR DESCRIPTION
I think there was a bug, you don't pass `.astylerc`, only `.astyle` when you detect that there is a file named `.astylerc`