### PR TITLE
fix: do not treat following "|" and strings as arguments in Autoformat command

### DIFF
--- a/plugin/autoformat.vim
+++ b/plugin/autoformat.vim
@@ -272,7 +272,7 @@ endfunction
 
 " Create a command for formatting the entire buffer
 " Save and recall window state to prevent vim from jumping to line 1
-command! -nargs=? -range=% -complete=filetype Autoformat let winview=winsaveview()|<line1>,<line2>call s:TryAllFormatters(<f-args>)|call winrestview(winview)
+command! -nargs=? -range=% -complete=filetype -bar Autoformat let winview=winsaveview()|<line1>,<line2>call s:TryAllFormatters(<f-args>)|call winrestview(winview)
 
 
 " Functions for iterating through list of available formatters


### PR DESCRIPTION
related issue: https://github.com/Chiel92/vim-autoformat/issues/124
copy from this code: https://github.com/rhysd/vim-crystal/blob/master/ftplugin/crystal.vim#L51