### PR TITLE
fixed invalid syntax with python 2.6.6

### DIFF
--- a/plugin/autoformat.vim
+++ b/plugin/autoformat.vim
@@ -186,7 +186,11 @@ if int(vim.eval('exists("g:formatterpath")')):
 
 # When an entry is unicode, Popen can't deal with it in Python 2.
 # As a pragmatic fix, we'll omit that entry.
-env = {key : val for key, val in env.iteritems() if type(key) == type(val) == str}
+newenv = {}
+for key,val in env.iteritems():
+    if type(key) == type(val) == str:
+        newenv[key] = val
+env=newenv
 p = subprocess.Popen(formatprg, env=env, shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE)
 stdoutdata, stderrdata = p.communicate(text)
 


### PR DESCRIPTION
this fixes this error i was getting with python 2.6.6 and redhat6
should do exactly the same thing just in a less "pretty" python way.

Error detected while processing function Reformat[2]..<SNR>133_TryAllFormatters[47]..<SNR>133_TryFormatterPython:
line   46:
  File "<string>", line 14
    env = {key : val for key, val in env.iteritems() if type(key) == type(val) == str}
                       ^
SyntaxError: invalid syntax
Press ENTER or type command to continue
