### PR TITLE
Support custom line lengths with yapf Python formatter.

### DIFF
--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -42,7 +42,7 @@ if !exists('g:formatter_yapf_style')
     let g:formatter_yapf_style = 'pep8'
 endif
 if !exists('g:formatdef_yapf')
-    let g:formatdef_yapf = "'yapf --style=\"{based_on_style:'.g:formatter_yapf_style.',indent_width:'.&shiftwidth.'}\" -l '.a:firstline.'-'.a:lastline"
+    let g:formatdef_yapf = "'yapf --style=\"{based_on_style:'.g:formatter_yapf_style.',indent_width:'.&shiftwidth.',column_limit:'.&textwidth.'}\" -l '.a:firstline.'-'.a:lastline"
 endif
 
 if !exists('g:formatters_python')


### PR DESCRIPTION
The 'column-width' option was added to the default yapf command. The
value is set to match the 'textwdith' value of the current buffer.