### PR TITLE
Rustfmt can reformat part of a file.

### DIFF
--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -295,7 +295,7 @@ endif
 
 " Rust
 if !exists('g:formatdef_rustfmt')
-    let g:formatdef_rustfmt = '"rustfmt"'
+    let g:formatdef_rustfmt = "'rustfmt --file-lines ''[{\"file\": \"' . expand('%:p') . '\", \"range\": [' . a:firstline . ',' . a:lastline . ']}]'''"
 endif
 
 if !exists('g:formatters_rust')


### PR DESCRIPTION
Fixes #170.
One trouble: when I run `:Autoformat` with my modification, it correctly reformat the selected part of the file, but deletes everything in the buffer. I have to do `:e!` to see the changes.