### PR TITLE
Set tidy_xml as the default formatter for SVG files

### DIFF
--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -287,6 +287,10 @@ if !exists('g:formatters_xml')
     let g:formatters_xml = ['tidy_xml']
 endif
 
+" SVG
+if !exists('g:formatters_svg')
+    let g:formatters_svg = ['tidy_xml']
+endif
 
 " XHTML
 if !exists('g:formatdef_tidy_xhtml')


### PR DESCRIPTION
SVG is just XML + namespace, so tidy_xml is a good default formatter for
SVG files.