### PR TITLE
Respect global YAPF config file

### DIFF
--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -49,7 +49,7 @@ if !exists('g:formatdef_yapf')
 endif
 
 function! g:YAPFFormatConfigFileExists()
-    return len(findfile(".style.yapf", expand("%:p:h").";")) || len(findfile("setup.cfg", expand("%:p:h").";"))
+    return len(findfile(".style.yapf", expand("%:p:h").";")) || len(findfile("setup.cfg", expand("%:p:h").";")) || filereadable(exists('$XDG_CONFIG_HOME') ? expand('$XDG_CONFIG_HOME/yapf/style') : expand('~/.config/yapf/style'))
 endfunction
 
 if !exists('g:formatters_python')


### PR DESCRIPTION
YAPF checks for a [global style](https://github.com/google/yapf/blob/master/yapf/yapflib/style.py#L546):

    os.path.join(
        os.getenv('XDG_CONFIG_HOME') or os.path.expanduser('~/.config'), 'yapf',
        'style'))

However this was not reflected in `g:YAPFFormatConfigFileExists()` and thus the noconfigfile_def is used instead of the global style when present. This PR fixes that.