### PR TITLE
Support fixjson; a JSON fixer/formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,10 @@ Here is a list of formatprograms that are supported by default, and thus will be
 * `fprettify` for modern __Fortran__.
   Download from [official repository](https://github.com/pseewald/fprettify). Install with `./setup.py install` or `./setup.py install --user`.
 
+* `fixjson` for JSON.
+  It is a JSON file fixer/formatter for humans using (relaxed) JSON5. It fixes various failures while humans writing JSON and formats JSON codes.
+  It can be installed with `npm install -g fixjson`. More info is available at https://github.com/rhysd/fixjson.
+
 ## Help, the formatter doesn't work as expected!
 
 If you're struggling with getting a formatter to work, it may help to set vim-autoformat in

--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -264,10 +264,15 @@ if !exists('g:formatdef_jsbeautify_json')
     endif
 endif
 
+if !exists('g:formatdef_fixjson')
+    let g:formatdef_fixjson =  '"fixjson"'
+endif
+
 
 if !exists('g:formatters_json')
     let g:formatters_json = [
                 \ 'jsbeautify_json',
+                \ 'fixjson',
                 \ ]
 endif
 


### PR DESCRIPTION
[fixjson](https://github.com/rhysd/fixjson) is a JSON file fixer/formatter for humans using (relaxed) JSON5. It formats a JSON code and fixes some trivial errors at the same time.

I added support for fixjson to vim-autoformat.

Following is an example of fixes with this PR:

![tmp](https://user-images.githubusercontent.com/823277/34919415-00a509bc-f9a7-11e7-86b4-915e1443303f.gif)
