### PR TITLE
Add shfmt as a default formatter for shell files

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,9 @@ Here is a list of formatprograms that are supported by default, and thus will be
   It is a JSON file fixer/formatter for humans using (relaxed) JSON5. It fixes various failures while humans writing JSON and formats JSON codes.
   It can be installed with `npm install -g fixjson`. More info is available at https://github.com/rhysd/fixjson.
 
+* `shfmt` for __Shell__.
+  A shell formatter written in Go supporting POSIX Shell, Bash and mksh that can be installed with `go get -u mvdan.cc/sh/cmd/shfmt`. See https://github.com/mvdan/sh for more info.
+
 
 ## Help, the formatter doesn't work as expected!
 

--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -453,3 +453,12 @@ endif
 if !exists('g:formatters_elixir')
     let g:formatters_elixir = ['mix_format']
 endif
+
+" Shell
+if !exists('g:formatdef_shfmt')
+    let g:formatdef_shfmt = '"shfmt -i ".(&expandtab ? shiftwidth() : "0")'
+endif
+
+if !exists('g:formatters_sh')
+    let g:formatters_sh = ['shfmt']
+endif


### PR DESCRIPTION
I thought a shell autoformat was sort of missing still, and [`shfmt`](https://github.com/mvdan/sh) does a decent job.
It takes into account vim indentation style dynamically (shiftwidth or tabs) as recommended.