### PR TITLE
Improve prettier configuration (json, js, ts, markdown, graphql, less, scss)

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ Here is a list of formatprograms that are supported by default, and thus will be
 * `shfmt` for __Shell__.
   A shell formatter written in Go supporting POSIX Shell, Bash and mksh that can be installed with `go get -u mvdan.cc/sh/cmd/shfmt`. See https://github.com/mvdan/sh for more info.
 
+* `prettier` for __JavaScript, TypeScript, CSS, SCSS, Less, JSX, GraphQL, JSON, Markdown__
+  `prettier` is a code formatter written in JavaScript. To install it, run `npm install -g prettier`.
+  It is the default formatter for Less and GraphQL.
+
 
 ## Help, the formatter doesn't work as expected!
 

--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -21,6 +21,10 @@ if !exists('g:autoformat_verbosemode')
     let g:autoformat_verbosemode = 0
 endif
 
+if !exists('g:formatdef_prettier')
+    let g:formatdef_prettier = '"prettier"'
+endif
+
 
 " Python
 if !exists('g:formatdef_autopep8')
@@ -159,12 +163,6 @@ if !exists('g:formatdef_standard_javascript')
     let g:formatdef_standard_javascript = '"standard --fix --stdin"'
 endif
 
-if !exists('g:formatdef_prettier_javascript')
-    if filereadable('.prettierrc')
-        let g:formatdef_prettier_javascript = '"prettier"'
-    endif
-endif
-
 " This is an xo formatter (inspired by the above eslint formatter)
 " To support ignore and overrides options, we need to use a tmp file
 " So we create a tmp file here and then remove it afterwards
@@ -254,7 +252,7 @@ if !exists('g:formatters_javascript')
                 \ 'jsbeautify_javascript',
                 \ 'jscs',
                 \ 'standard_javascript',
-                \ 'prettier_javascript',
+                \ 'prettier',
                 \ 'xo_javascript',
                 \ ]
 endif
@@ -274,11 +272,11 @@ if !exists('g:formatdef_fixjson')
     let g:formatdef_fixjson =  '"fixjson"'
 endif
 
-
 if !exists('g:formatters_json')
     let g:formatters_json = [
                 \ 'jsbeautify_json',
                 \ 'fixjson',
+                \ 'prettier',
                 \ ]
 endif
 
@@ -343,9 +341,8 @@ if !exists('g:formatdef_cssbeautify')
 endif
 
 if !exists('g:formatters_css')
-    let g:formatters_css = ['cssbeautify']
+    let g:formatters_css = ['cssbeautify', 'prettier']
 endif
-
 
 " SCSS
 if !exists('g:formatdef_sassconvert')
@@ -353,9 +350,13 @@ if !exists('g:formatdef_sassconvert')
 endif
 
 if !exists('g:formatters_scss')
-    let g:formatters_scss = ['sassconvert']
+    let g:formatters_scss = ['sassconvert', 'prettier']
 endif
 
+" Less
+if !exists('g:formatters_less')
+    let g:formatters_less = ['prettier']
+endif
 
 " Typescript
 if !exists('g:formatdef_tsfmt')
@@ -363,7 +364,7 @@ if !exists('g:formatdef_tsfmt')
 endif
 
 if !exists('g:formatters_typescript')
-    let g:formatters_typescript = ['tsfmt']
+    let g:formatters_typescript = ['tsfmt', 'prettier']
 endif
 
 
@@ -439,7 +440,12 @@ if !exists('g:formatdef_remark_markdown')
 endif
 
 if !exists('g:formatters_markdown')
-    let g:formatters_markdown = ['remark_markdown']
+    let g:formatters_markdown = ['remark_markdown', 'prettier']
+endif
+
+" Graphql
+if !exists('g:formatters_graphql')
+    let g:formatters_graphql = ['prettier']
 endif
 
 " Fortran


### PR DESCRIPTION
Hi! 

This PR 
  * correct a bug: for javascript prettier doesn't need .prettierrc to work
  * add filetype definitions for json, ts, markdown, graphql, less, scss