### PR TITLE
Use normal! to autointent code

### DIFF
--- a/plugin/autoformat.vim
+++ b/plugin/autoformat.vim
@@ -169,7 +169,7 @@ function! s:Fallback()
             echomsg "Autoindenting..."
         endif
         " Autoindent code
-        exe "normal gg=G"
+        exe "normal! gg=G"
     endif
 
 endfunction


### PR DESCRIPTION
... otherwise might not work as expected if the user remapped any of the commands used. See [here](http://learnvimscriptthehardway.stevelosh.com/chapters/29.html) about `normal!`.