### PR TITLE
add support for autoformat selected lines in visual mode when using clang-format

### DIFF
--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -75,7 +75,13 @@ endif
 
 " Generic C, C++, Objective-C
 if !exists('g:formatdef_clangformat')
-    let s:configfile_def = "'clang-format -lines='.a:firstline.':'.a:lastline.' --assume-filename=\"'.expand('%:p').'\" -style=file'"
+    if mode() == "v"
+        let s:configfile_def = "'clang-format -lines=line("v"):line(".") --assume-filename=\"'.expand('%:p').'\" -style=file'"
+    else
+        let s:configfile_def = "'clang-format -lines='.a:firstline.':'.a:lastline.' --assume-filename=\"'.expand('%:p').'\" -style=file'"
+    end
+
+    " let s:configfile_def = "'clang-format -lines='.a:firstline.':'.a:lastline.' --assume-filename=\"'.expand('%:p').'\" -style=file'"
     let s:noconfigfile_def = "'clang-format -lines='.a:firstline.':'.a:lastline.' --assume-filename=\"'.expand('%:p').'\" -style=\"{BasedOnStyle: WebKit, AlignTrailingComments: true, '.(&textwidth ? 'ColumnLimit: '.&textwidth.', ' : '').(&expandtab ? 'UseTab: Never, IndentWidth: '.shiftwidth() : 'UseTab: Always').'}\"'"
     let g:formatdef_clangformat = "g:ClangFormatConfigFileExists() ? (" . s:configfile_def . ") : (" . s:noconfigfile_def . ")"
 endif


### PR DESCRIPTION
Initially, this vim script will auto format the whole file when using clang-format. But sometimes it is useful to do format only upon several lines. I add support for formatting selected lines in visual mode when using clang-format.