### PR TITLE
Update irrelevant JSCS site link

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Here is a list of formatprograms that are supported by default, and thus will be
   The python version version is also supported by default, which does not need `nodejs` to run.
   Here is the link to the repository: https://github.com/einars/js-beautify.
 
-* `JSCS` for __Javascript__. http://jscs.info/
+* `JSCS` for __Javascript__. https://jscs-dev.github.io/
 
 * `standard` for __Javascript__.
   It can be installed by running `npm install -g standard` (`nodejs` is required). No more configuration needed.


### PR DESCRIPTION
jscs.info appears to have nothing to do with the linter, and just contains a blogpost about student debt.
This appears to be the closest to canonical site for the project (although it's now merged with ESLint I suppose some still use it?)