### PR TITLE
add default formatter for proto files

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ separated by dots (`.`).
 
 Here is a list of formatprograms that are supported by default, and thus will be detected and used by vim when they are installed properly.
 
-* `clang-format` for __C__, __C++__, __Objective-C__ (supports formatting ranges).
+* `clang-format` for __C__, __C++__, __Objective-C__, __Protobuf__ (supports formatting ranges).
   Clang-format is a product of LLVM source builds.
   If you `brew install llvm`, clang-format can be found in /usr/local/Cellar/llvm/bin/.
   Vim-autoformat checks whether there exists a `.clang-format` or a `_clang-format` file up in

--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -128,6 +128,12 @@ if !exists('g:formatters_objc')
 endif
 
 
+" Protobuf
+if !exists('g:formatters_proto')
+    let g:formatters_proto = ['clangformat']
+endif
+
+
 " Java
 if !exists('g:formatdef_astyle_java')
     if filereadable('.astylerc')


### PR DESCRIPTION
This change will set the default formatter for protobuf (`.proto`) files to be `clang-format`, which is the most common formatter for protobuf files.