### PR TITLE
Add cmake support with cmake-format

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,9 @@ Here is a list of formatprograms that are supported by default, and thus will be
 * `sqlformat` for __SQL__.
   Install `sqlparse` with `pip`.
 
+* `cmake-format` for __CMake__.
+  Install `cmake_format` with `pip`. See https://github.com/cheshirekow/cmake_format for more info.
+
 
 ## Help, the formatter doesn't work as expected!
 

--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -503,3 +503,12 @@ endif
 if !exists('g:formatters_sql')
     let g:formatters_sql = ['sqlformat']
 endif
+
+" CMake
+if !exists('g:formatdef_cmake_format')
+    let g:formatdef_cmake_format = '"cmake-format - --tab-size ".shiftwidth()." ".(&textwidth ? "--line-width=".&textwidth : "")'
+endif
+
+if !exists('g:formatters_cmake')
+    let g:formatters_cmake = ['cmake_format']
+endif


### PR DESCRIPTION
Set the default formatter for cmake files to `cmake-format`. `shiftwidth` and `textwidth` are taken into account.