### PR TITLE
Add LaTeX support with latexindent.pl

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,9 @@ Here is a list of formatprograms that are supported by default, and thus will be
 * `cmake-format` for __CMake__.
   Install `cmake_format` with `pip`. See https://github.com/cheshirekow/cmake_format for more info.
 
+* `latexindent.pl` for __LaTeX__.
+  Installation instructions at https://github.com/cmhughes/latexindent.pl.
+
 
 ## Help, the formatter doesn't work as expected!
 

--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -512,3 +512,12 @@ endif
 if !exists('g:formatters_cmake')
     let g:formatters_cmake = ['cmake_format']
 endif
+
+" Latex
+if !exists('g:formatdef_latexindent')
+    let g:formatdef_latexindent = '"latexindent.pl -"'
+endif
+
+if !exists('g:formatters_latex')
+    let g:formatters_tex = ['latexindent']
+endif


### PR DESCRIPTION
Set the default formatter for LaTeX files to `latexindent.pl`. `shiftwidth` could probably be set as well, but `latexindent.pl` takes command line options in YAML format. For example, `latexindent.pl -y="defaultIndent:'\t'"` will set the default indent to one tab character. So I'm not sure how to make this play nice with vim.