### PR TITLE
Prefix the current directory to location to path of eslint

### DIFF
--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -207,6 +207,8 @@ if !exists('g:formatdef_eslint_local')
             if empty(l:prog)
                 let l:prog = findfile('/usr/local/bin/eslint')
             endif
+        else
+            let l:prog = getcwd()."/".l:prog
         endif
 
         "initial


### PR DESCRIPTION
The assumption here is that when using eslint from the local/project
node_modules, the user is located in the projects root directory. If
not, the global eslint should be used. If you want to use node_modules
from somewhere else e.g. your user home directory. This might fail, in
that case either use the global one or revert this commit and use it or
update the code to conditionally add cwd.