### PR TITLE
rustfmt: Default to --edition 2018

### DIFF
--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -401,7 +401,7 @@ endif
 
 " Rust
 if !exists('g:formatdef_rustfmt')
-    let g:formatdef_rustfmt = '"rustfmt"'
+    let g:formatdef_rustfmt = '"rustfmt --edition 2018"'
 endif
 
 if !exists('g:formatters_rust')


### PR DESCRIPTION
It's probably sensible to do this as all new code will be created with `--edition 2018` and people will just expect it to work.