### PR TITLE
add ocaml formatters:  ocamlformat(default) & ocp-indent

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,10 @@ Here is a list of formatprograms that are supported by default, and thus will be
 * `latexindent.pl` for __LaTeX__.
   Installation instructions at https://github.com/cmhughes/latexindent.pl.
 
+* `ocamlformat` for __OCaml__.
+  OCamlFormat can be installed with opam: `opam install ocamlformat`.
+  Details: https://github.com/ocaml-ppx/ocamlformat.
+
 
 ## Help, the formatter doesn't work as expected!
 
@@ -352,7 +356,7 @@ would then only format the selected part.
 
 ## Contributing
 
-This project is community driven. I don't actively do development on vim-autoformat myself, 
+This project is community driven. I don't actively do development on vim-autoformat myself,
 as it's current state fulfills my personal needs.
 However, I will review pull requests and keep an eye on the general sanity of the code.
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ Here is a list of formatprograms that are supported by default, and thus will be
 * `ocamlformat` for __OCaml__.
   OCamlFormat can be installed with opam: `opam install ocamlformat`.
   Details: https://github.com/ocaml-ppx/ocamlformat.
+  We also provide `ocp-indent` for OCaml, but it's not enabled by default, if you prefer `ocp-indent` rather than `ocamlformat`, you can set `let g:formatters_ocaml = ['ocp_indent']` in your `.vimrc`.
 
 
 ## Help, the formatter doesn't work as expected!

--- a/README.md
+++ b/README.md
@@ -257,8 +257,7 @@ Here is a list of formatprograms that are supported by default, and thus will be
 * `ocamlformat` for __OCaml__.
   OCamlFormat can be installed with opam: `opam install ocamlformat`.
   Details: https://github.com/ocaml-ppx/ocamlformat.
-  We also provide `ocp-indent` for OCaml, but it's not enabled by default, if you prefer `ocp-indent` rather than `ocamlformat`, you can set `let g:formatters_ocaml = ['ocp_indent']` in your `.vimrc`.
-
+  We also provide `ocp-indent` as reserve formatter.
 
 ## Help, the formatter doesn't work as expected!
 

--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -521,3 +521,16 @@ endif
 if !exists('g:formatters_latex')
     let g:formatters_tex = ['latexindent']
 endif
+
+" OCaml
+if !exists('g:formatdef_ocp_indent')
+    let g:formatdef_ocp_indent = '"ocp-indent"'
+endif
+
+if !exists('g:formatdef_ocamlformat')
+    let g:formatdef_ocamlformat = '"ocamlformat --name " . expand("%:p") . " -"'
+endif
+
+if !exists('g:formatters_ocaml')
+    let g:formatters_ocaml = ['ocamlformat']
+endif

--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -532,5 +532,5 @@ if !exists('g:formatdef_ocamlformat')
 endif
 
 if !exists('g:formatters_ocaml')
-    let g:formatters_ocaml = ['ocamlformat']
+    let g:formatters_ocaml = ['ocamlformat', 'ocp_indent']
 endif


### PR DESCRIPTION
Add predefined ocaml formatters:

* ocamlformat (default)
* ocp-indent

Testing passed:

<img width="557" alt="Screenshot 2020-01-08 at 9 29 57 PM" src="https://user-images.githubusercontent.com/23468295/71982021-a2ed5980-325e-11ea-965e-041b1dc465d2.png">

<img width="402" alt="Screenshot 2020-01-08 at 9 30 54 PM" src="https://user-images.githubusercontent.com/23468295/71982032-a7197700-325e-11ea-8924-eebdc7487fb9.png">


