### PR TITLE
Fix latexindent failure on help text

### DIFF
--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -517,7 +517,7 @@ endif
 
 " Latex
 if !exists('g:formatdef_latexindent')
-    let g:formatdef_latexindent = '"latexindent.pl -"'
+    let g:formatdef_latexindent = '"latexindent.pl - 2>/dev/null"'
 endif
 
 if !exists('g:formatters_latex')


### PR DESCRIPTION
Should fix https://github.com/Chiel92/vim-autoformat/issues/282.

See https://github.com/cmhughes/latexindent.pl/issues/120.