### PR TITLE
Add installation note for neovim user

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,25 @@ You can easily customize existing formatprogram definitions or add your own form
 When no formatprogram exists (or no formatprogram is installed) for a certain filetype,
 vim-autoformat falls back by default to indenting, (using vim's auto indent functionality), retabbing and removing trailing whitespace.
 
-## How to install
+## Requirement
+vim-autoformat requires vim to have python support (python 2 or python 3). You can check your vim has python support by running `:echo has("python3")` and `:echo has("python2")`.
 
-This plugin is supported by Vim 7.4+.
-It is required that your vim has builtin python support. You can check whether this is the case
-by running `vim --version` and check that `+python` or `+python3` is listed among features.
+__Neovim__
+Neovim does not come with python support by default, and additional setup is required.
+
+First install [pynvim](https://github.com/neovim/pynvim)
+```
+python3 -m pip install pynvim
+```
+
+And add the following configuration in your vimdc
+
+```
+let g:python3_host_prog=/path/to/python/executable/
+```
+
+
+## How to install
 
 #### Vundle
 


### PR DESCRIPTION
I received this error when trying to use vim-autoformat on Neovim. 

```
WARNING: vim has no support for python, but it is required to run the formatter!
```

The PR adds an additional guide for Neovim users on the required setup for this plugin.