### PR TITLE
allow ocamlformat to work outside project

### DIFF
--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -530,7 +530,11 @@ if !exists('g:formatdef_ocp_indent')
 endif
 
 if !exists('g:formatdef_ocamlformat')
-    let g:formatdef_ocamlformat = '"ocamlformat --name " . expand("%:p") . " -"'
+    if filereadable('.ocamlformat')
+        let g:formatdef_ocamlformat = '"ocamlformat --enable-outside-detected-project --name " . expand("%:p") . " -"'
+    else
+        let g:formatdef_ocamlformat = '"ocamlformat --profile=ocamlformat --enable-outside-detected-project --name " . expand("%:p") . " -"'
+    endif
 endif
 
 if !exists('g:formatters_ocaml')


### PR DESCRIPTION
Allow ocamlformat to work outside project (by enabling `--enable-outside-detected-project`):

1. `.ocamlformat` found: read format options from `.ocamlformat`.
2. `.ocamlformat` not found: use `--profile=ocamlformat` as default option.