### PR TITLE
Update `formatdef_prettier` for Prettier 2.0

### DIFF
--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -171,7 +171,7 @@ endif
 
 
 if !exists('g:formatdef_prettier')
-    let g:formatdef_prettier = '"prettier --stdin --stdin-filepath ".expand("%:p").(&textwidth ? " --print-width ".&textwidth : "")." --tab-width=".shiftwidth()'
+    let g:formatdef_prettier = '"prettier --stdin-filepath ".expand("%:p").(&textwidth ? " --print-width ".&textwidth : "")." --tab-width=".shiftwidth()'
 endif
 
 


### PR DESCRIPTION
Prettier 2.0 [deprecates the `--stdin` flag](https://prettier.io/blog/2020/03/21/2.0.0.html#remove---stdin-7668httpsgithubcomprettierprettierpull7668-by-thorn0httpsgithubcomthorn0) stating it was redundant and that it should simply be a warning with no change in exit code. Not sure if this plugin is watching for exit code or some other method to check for success, but after upgrading Prettier, formatting would not work until I removed the flag from `formatdef_prettier`!

I've note verified with a Prettier 1.0 project yet, but it sounds like it should be safe since that was the default mode it was operating in with or without the flag.