### PR TITLE
Add :AutoformatLine command to format a single line

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Or to have your code be formatted upon saving your file, you could use something
 au BufWrite * :Autoformat
 ```
 
+You can also format the current line only (without having to make a visual selection) by executing `:AutoformatLine`.
+
 To disable the fallback to vim's indent file, retabbing and removing trailing whitespace, set the following variables to 0.
 
 ```vim

--- a/plugin/autoformat.vim
+++ b/plugin/autoformat.vim
@@ -307,7 +307,14 @@ endfunction
 " Create a command for formatting the entire buffer
 " Save and recall window state to prevent vim from jumping to line 1
 " Write and read viminfo to restore marks
-command! -nargs=? -range=% -complete=filetype -bar Autoformat let winview=winsaveview()|wviminfo|<line1>,<line2>call s:TryAllFormatters(<f-args>)|call winrestview(winview)|rviminfo
+command! -nargs=? -range=% -complete=filetype -bar
+    \ Autoformat let winview=winsaveview()|wviminfo|<line1>,<line2>call s:TryAllFormatters(<f-args>)|call winrestview(winview)|rviminfo
+
+" Create a command for formatting a single line, or range of lines
+" Save and recall window state to prevent vim from jumping to line 1
+" Write and read viminfo to restore marks
+command! -nargs=? -range -complete=filetype -bar
+    \ AutoformatLine let winview=winsaveview()|wviminfo|<line1>,<line2>call s:TryAllFormatters(<f-args>)|call winrestview(winview)|rviminfo
 
 
 " Functions for iterating through list of available formatters


### PR DESCRIPTION
No need to visually select block containing single line, just run :AutoformatLine and current cursor line gets formatted.