### PR TITLE
Add support for bazel buildifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ let g:run_all_formatters_vue = 1
 
 Here is a list of formatprograms that are supported by default, and thus will be detected and used by vim when they are installed properly.
 
+* `buildifier` for __bazel__ build files. (https://github.com/bazelbuild/buildtools/tree/master/buildifier)
+
 * `clang-format` for __C__, __C++__, __Objective-C__, __Protobuf__ (supports formatting ranges).
   Clang-format is a product of LLVM source builds.
   If you `brew install llvm`, clang-format can be found in /usr/local/Cellar/llvm/bin/.

--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -76,6 +76,10 @@ if !exists('g:formatters_cs')
     let g:formatters_cs = ['astyle_cs']
 endif
 
+if !exists('g:formatters_bzl')
+    let g:formatters_bzl = ['buildifier']
+endif
+
 
 " Generic C, C++, Objective-C
 if !exists('g:formatdef_clangformat')


### PR DESCRIPTION
That was amazingly easy. Of course, it is up to the user to make sure `buildifier` just works, but that's the same for all formatters. In this case, user should e.g.:

```
sudo apt install golang-go
go get github.com/bazelbuild/buildtools/buildifier
```

and then add `~/go/bin` to PATH. I think those steps are obvious to anyone using bazel.