### PR TITLE
Search user-level clang-format config

### DIFF
--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -89,7 +89,7 @@ if !exists('g:formatdef_clangformat')
 endif
 
 function! g:ClangFormatConfigFileExists()
-    return len(findfile(".clang-format", expand("%:p:h").";")) || len(findfile("_clang-format", expand("%:p:h").";"))
+    return len(findfile(".clang-format", expand("%:p:h").";")) || len(findfile("_clang-format", expand("%:p:h").";")) || len(findfile("~/.clang-format", expand("%:p:h").";")) || len(findfile("~/_clang-format", expand("%:p:h").";"))
 endfunction
 
 


### PR DESCRIPTION
Putting a `.clang-format` file in every C++/C project is troublesome, and single file C++/C test-purpose projects are common. There are also widely-used C++/C code styles like Google that may be used in someone's almost all projects. 

The PR tries to search `~/.clang-format` and `~/_clang-format` after searching `.clang-format` and `_clang-format`.

 Though this is not standard behavior of clang-format, the PR may make it more convenient for developers.